### PR TITLE
Add specific flags for sshd service

### DIFF
--- a/files/etc/ssh/sshd_config
+++ b/files/etc/ssh/sshd_config
@@ -13,13 +13,13 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 HostKey /etc/ssh/ssh_host_rsa_key
 
 # Ensure only approved Key Exchange algorithms are used
-KexAlgorithms curve25519-sha256@libssh.org
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
 
 # Ensure only approved Ciphers algorithms are used
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 
 # Ensure only approved MAC algorithms are used
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256
 
 # Ensure only approved HostKeyAlgorithms algorithms are used
 HostKeyAlgorithms ssh-rsa,ssh-ed25519,rsa-sha2-256,rsa-sha2-512


### PR DESCRIPTION
This flags are added to specific key types, and MACs algorithms, to solve a issue with ssh from GCP portal. Before add, the behaviour of ssh are to drop the connection from the temporary generated keys.